### PR TITLE
Post#published is not available in newer Jekyll versions, fixes #25

### DIFF
--- a/lib/pagoda/jekyll_mod.rb
+++ b/lib/pagoda/jekyll_mod.rb
@@ -23,7 +23,7 @@ module Jekyll
         if Post.valid?(f)
           post = Post.new(self, self.source, dir, f)
 
-          if (not post.published )
+          if (not post.published? )
             drafts << post
           end
         end
@@ -32,5 +32,9 @@ module Jekyll
       drafts
     end
 
+  end
+
+  class Post
+    alias_method :published?, :published unless defined?(:published?)
   end
 end


### PR DESCRIPTION
Post#published is not available in Jekyll since this commit https://github.com/jekyll/jekyll/commit/09c6ff4f9c9568c103788e2d7f0c9804c7706492
